### PR TITLE
feat: add LLM-assisted rule generation via riveter generate-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ riveter scan-state -p aws-security -s terraform.tfstate
 # Pipe remote state from any Terraform backend
 terraform state pull | riveter scan-state -p aws-security -s -
 
+# Generate rules for your Terraform files using AI (requires ANTHROPIC_API_KEY)
+riveter generate-rules -t ./infra/ -o my-rules.yml
+riveter scan -r my-rules.yml -t ./infra/
+
 # See available rule packs
 riveter list-rule-packs
 ```
@@ -81,6 +85,18 @@ Validates a Terraform **state file** against rules for drift detection.
 | `--debug` | | Enable debug logging |
 
 > **State format:** Requires Terraform state format v4 (Terraform 0.13+). Data sources are automatically excluded — only managed resources are validated.
+
+### `riveter generate-rules`
+
+Uses Claude to suggest 3–5 enforceable Riveter rules per resource type found in your Terraform files. Output is a valid rules YAML file you can review, customize, and pass to `riveter scan -r`. Requires `ANTHROPIC_API_KEY`.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--terraform PATH` | `-t` | **Required.** Path to a `.tf` file or directory |
+| `--output FILE` | `-o` | Write generated rules to a file (default: stdout) |
+| `--focus TEXT` | | Guide the AI, e.g. `"PCI-DSS compliance"` or `"cost optimization"` |
+| `--model MODEL` | | Override the Claude model |
+| `--debug` | | Enable debug logging |
 
 ### `riveter list-rule-packs`
 
@@ -242,21 +258,39 @@ Generates a self-contained HTML report with no external dependencies. Open in an
 
 ---
 
-## AI-Powered Explanations (Optional)
+## AI Features (Optional)
 
-Riveter can explain violations in plain English — why a rule matters, what the risk is, and
-exactly how to fix it in your Terraform config.
-
-This feature requires an Anthropic API key (pay-as-you-go, ~$0.001 per explanation).
-Get one at https://console.anthropic.com.
-
-Once you have a key:
+Both AI features require an Anthropic API key (pay-as-you-go).
+Get one at https://console.anthropic.com, then export it:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-Then add `--explain` to any scan:
+### Rule Generation
+
+Don't know where to start with rules? Let Claude write a first draft based on your actual Terraform:
+
+```bash
+# Generate rules and print to stdout
+riveter generate-rules -t ./infra/
+
+# Save to a file and scan immediately
+riveter generate-rules -t ./infra/ -o my-rules.yml
+riveter scan -r my-rules.yml -t ./infra/
+
+# Focus on a specific compliance framework
+riveter generate-rules -t main.tf --focus "PCI-DSS compliance" -o pci-rules.yml
+```
+
+Riveter parses your Terraform, groups resources by type, and calls Claude once per type to suggest 3–5 enforceable rules. Each rule is validated against the rule schema before output — invalid suggestions are silently dropped. Always review and test generated rules before enforcing them in CI.
+
+### Violation Explanations
+
+Riveter can explain violations in plain English — why a rule matters, what the risk is, and
+exactly how to fix it in your Terraform config.
+
+Add `--explain` to any scan (cost: ~$0.001 per explanation):
 
 ```bash
 riveter scan -p aws-security -t main.tf --explain
@@ -274,7 +308,8 @@ To always enable explanations, add this to `riveter.yml`:
 ```yaml
 ai:
   explain_on_fail: true
-  model: claude-sonnet-4-20250514   # optional — overrides the default model
+  model: claude-sonnet-4-20250514      # optional — overrides the default model
+  generate_model: claude-sonnet-4-20250514  # optional — model used for generate-rules
 ```
 
 > **Note:** `--explain` is available on `riveter scan` only, not `scan-state`.
@@ -304,7 +339,8 @@ exclude_rules:
 
 ai:
   explain_on_fail: true
-  model: claude-sonnet-4-20250514   # optional
+  model: claude-sonnet-4-20250514        # optional — model for --explain
+  generate_model: claude-sonnet-4-20250514  # optional — model for generate-rules
 ```
 
 CLI flags always override config file values.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,8 +14,9 @@ This guide covers everything you need to use Riveter to validate Terraform confi
 6. [Output Formats](#output-formats)
 7. [Filtering](#filtering)
 8. [State File Scanning](#state-file-scanning)
-9. [CI/CD Integration](#cicd-integration)
-10. [Troubleshooting](#troubleshooting)
+9. [AI Features](#ai-features)
+10. [CI/CD Integration](#cicd-integration)
+11. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -401,6 +402,106 @@ riveter scan-state -p aws-security -s terraform.tfstate -f html > state-report.h
 | `--exclude-rules PATTERN` | | Skip matching rules (repeatable) |
 | `--config FILE` | `-c` | Config file (auto-detected if omitted) |
 | `--debug` | | Enable debug logging |
+
+---
+
+## AI Features
+
+Both AI features require an [Anthropic API key](https://console.anthropic.com) and the `anthropic` Python package. If you installed Riveter via Homebrew the package is included. Set the key in your environment:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Riveter degrades gracefully when no key is set — scans and rule loading work normally, AI features are simply skipped.
+
+---
+
+### Rule Generation (`generate-rules`)
+
+`riveter generate-rules` reads your Terraform files, groups resources by type, and asks Claude to suggest 3–5 enforceable rules per type. The output is a ready-to-use rules YAML file.
+
+**Basic usage:**
+
+```bash
+# Print generated rules to stdout
+riveter generate-rules -t main.tf
+
+# Save to a file
+riveter generate-rules -t ./infra/ -o my-rules.yml
+```
+
+**Scan with the generated rules:**
+
+```bash
+riveter scan -r my-rules.yml -t ./infra/
+```
+
+**Focus the AI on a specific area:**
+
+The `--focus` flag guides Claude toward a particular concern. Without it, general security and operational best practices are used.
+
+```bash
+riveter generate-rules -t main.tf --focus "PCI-DSS compliance" -o pci-rules.yml
+riveter generate-rules -t main.tf --focus "cost optimization" -o cost-rules.yml
+riveter generate-rules -t main.tf --focus "CIS AWS Foundations Benchmark" -o cis-rules.yml
+```
+
+**All flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--terraform PATH` | `-t` | **Required.** `.tf` file or directory |
+| `--output FILE` | `-o` | Write YAML to a file instead of stdout |
+| `--focus TEXT` | | Plain-text guidance for the AI |
+| `--model MODEL` | | Override the Claude model (default: `claude-sonnet-4-20250514`) |
+| `--debug` | | Enable debug logging |
+
+**Workflow tips:**
+
+- Generated rules are validated against the rule schema before output. Invalid suggestions (bad operators, missing required fields) are silently dropped.
+- Always review generated rules before enforcing them in CI — the AI may suggest rules based on attributes that are optional or environment-specific.
+- Use `--focus` to get more targeted output. Broad prompts produce broad rules; specific compliance frameworks produce specific rules.
+- Run `riveter scan -r generated.yml -t ./infra/` immediately after generating to see which rules have matches and which are SKIPPED.
+
+---
+
+### Violation Explanations (`--explain` / `explain`)
+
+Riveter can explain each violation in plain English: why the rule matters, what an attacker could do, and the exact Terraform change needed to fix it.
+
+**Inline during a scan:**
+
+```bash
+riveter scan -p aws-security -t main.tf --explain
+```
+
+Explanations appear underneath each failing row in the table. In JSON and HTML output, they are included in the structured result.
+
+Cost: approximately $0.001 per explanation.
+
+**Drill into a specific violation:**
+
+```bash
+riveter explain ec2_no_public_ip \
+    --resource aws_instance.web_server \
+    --terraform main.tf \
+    -p aws-security
+```
+
+This is useful when you want to understand a rule before fixing it, without re-running a full scan.
+
+**Always-on via config:**
+
+```yaml
+# riveter.yml
+ai:
+  explain_on_fail: true
+  model: claude-sonnet-4-20250514        # optional — default model for explanations
+  generate_model: claude-sonnet-4-20250514  # optional — model for generate-rules
+```
+
+> **Note:** `--explain` works on `riveter scan` only, not `scan-state`.
 
 ---
 

--- a/src/riveter/cli.py
+++ b/src/riveter/cli.py
@@ -7,6 +7,7 @@ Commands:
     riveter scan             Validate Terraform files against rules.
     riveter scan-state       Validate a Terraform state file (drift detection).
     riveter explain          AI-powered explanation of a single rule violation.
+    riveter generate-rules   AI-powered rule generation from Terraform files.
     riveter list-rule-packs  List all available built-in rule packs.
 """
 
@@ -17,6 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 
 import click
+import yaml
 from rich import box
 from rich.console import Console
 from rich.table import Table
@@ -24,6 +26,7 @@ from rich.table import Table
 from ._version import get_version
 from .config import ConfigManager
 from .explainer import Explainer
+from .generator import RuleGenerator
 from .extract_config import extract_terraform_config
 from .extract_state import extract_terraform_state
 from .formatters import HTMLFormatter, JSONFormatter, JUnitXMLFormatter, SARIFFormatter
@@ -842,4 +845,168 @@ def list_rule_packs() -> None:
         )
 
     console.print(table)
+
+
+@main.command(name="generate-rules")
+@click.option(
+    "--terraform",
+    "-t",
+    "terraform_path",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to a Terraform .tf file or directory of .tf files.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_file",
+    type=click.Path(),
+    default=None,
+    help="Write generated rules to this file instead of stdout.",
+)
+@click.option(
+    "--focus",
+    default=None,
+    metavar="TEXT",
+    help=(
+        "Optional guidance for the AI, e.g. 'PCI-DSS compliance', "
+        "'cost optimization', or 'security hardening'."
+    ),
+)
+@click.option(
+    "--model",
+    default=None,
+    metavar="MODEL",
+    help="Override the Claude model used for generation.",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help="Enable debug logging.",
+)
+def generate_rules(
+    terraform_path: str,
+    output_file: Optional[str],
+    focus: Optional[str],
+    model: Optional[str],
+    debug: bool,
+) -> None:
+    """Generate Riveter rules for your Terraform resources using AI.
+
+    Parses Terraform files, groups resources by type, and asks Claude to
+    suggest 3–5 enforceable rules per resource type.  The resulting YAML
+    can be passed directly to 'riveter scan -r <file>'.
+
+    Requires ANTHROPIC_API_KEY to be set in the environment.
+
+    \b
+    Examples:
+      # Print generated rules to stdout
+      riveter generate-rules -t main.tf
+
+      # Save to a file and scan immediately
+      riveter generate-rules -t ./infra/ -o my-rules.yml
+      riveter scan -r my-rules.yml -t ./infra/
+
+      # Focus on a specific compliance framework
+      riveter generate-rules -t main.tf --focus "PCI-DSS compliance" -o pci-rules.yml
+    """
+    _setup_logging(debug)
+
+    # -- Parse Terraform -------------------------------------------------------
+    try:
+        tf_config = extract_terraform_config(terraform_path)
+    except Exception as exc:
+        err_console.print(f"[red]Error parsing Terraform:[/red] {exc}")
+        sys.exit(1)
+
+    resources = tf_config.get("resources", [])
+    if not resources:
+        console.print("[yellow]Warning:[/yellow] No resources found in the Terraform path.")
+        sys.exit(0)
+
+    # -- Check AI availability -------------------------------------------------
+    generator = RuleGenerator(model=model)
+    if not generator.is_available():
+        err_console.print(
+            "\u26a0  AI rule generation requires an Anthropic API key.\n"
+            "   Set it with:\n"
+            "       export ANTHROPIC_API_KEY=sk-ant-...\n"
+            "   Get a key at: https://console.anthropic.com"
+        )
+        sys.exit(1)
+
+    # -- Group resources by type -----------------------------------------------
+    by_type: Dict[str, List[Dict[str, Any]]] = {}
+    for res in resources:
+        rt = res.get("resource_type", "unknown")
+        by_type.setdefault(rt, []).append(res)
+
+    resource_types = list(by_type.keys())
+    console.print(
+        f"\nGenerating rules for [bold]{len(resource_types)}[/bold] resource type(s) "
+        f"across [bold]{len(resources)}[/bold] resource(s)...\n"
+    )
+
+    # -- Generate rules concurrently per resource type -------------------------
+    all_rules: List[Dict[str, Any]] = []
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = {
+            executor.submit(
+                generator.generate_for_resource_type,
+                rt,
+                by_type[rt][0],  # use first instance as representative sample
+                focus,
+            ): rt
+            for rt in resource_types
+        }
+        for future in as_completed(futures):
+            rt = futures[future]
+            try:
+                rules = future.result()
+                if rules:
+                    all_rules.extend(rules)
+                    console.print(
+                        f"  [green]\u2713[/green] {rt}: {len(rules)} rule(s) generated"
+                    )
+                else:
+                    console.print(f"  [yellow]\u2013[/yellow] {rt}: no valid rules returned")
+            except Exception:  # noqa: BLE001
+                console.print(f"  [red]\u2717[/red] {rt}: generation failed")
+
+    warning = generator.get_warning()
+    if warning:
+        err_console.print(warning)
+
+    if not all_rules:
+        err_console.print(
+            "\n[red]No rules were generated.[/red] "
+            "Try running with --debug for more details."
+        )
+        sys.exit(1)
+
+    # -- Serialise to YAML -----------------------------------------------------
+    header = (
+        "# Generated by riveter generate-rules\n"
+        "# Review and customize before use:\n"
+        "#   riveter scan -r <this-file> -t <terraform-path>\n\n"
+    )
+    rules_yaml = yaml.dump({"rules": all_rules}, default_flow_style=False, sort_keys=False)
+    output = header + rules_yaml
+
+    if output_file:
+        try:
+            with open(output_file, "w") as fh:
+                fh.write(output)
+            console.print(
+                f"\n[bold green]Generated {len(all_rules)} rule(s)[/bold green] "
+                f"written to [bold]{output_file}[/bold]"
+            )
+        except OSError as exc:
+            err_console.print(f"[red]Error writing output file:[/red] {exc}")
+            sys.exit(1)
+    else:
+        console.print()
+        click.echo(output)
     console.print(f"\n[dim]Found {len(packs)} rule pack(s)[/dim]")

--- a/src/riveter/config.py
+++ b/src/riveter/config.py
@@ -72,6 +72,9 @@ class RiveterConfig:
     ai_explain_on_fail: bool = False
     ai_model: Optional[str] = None
 
+    # AI rule generation (optional — requires anthropic package + ANTHROPIC_API_KEY)
+    ai_generate_model: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "rule_dirs": self.rule_dirs,
@@ -84,6 +87,7 @@ class RiveterConfig:
             "debug": self.debug,
             "ai_explain_on_fail": self.ai_explain_on_fail,
             "ai_model": self.ai_model,
+            "ai_generate_model": self.ai_generate_model,
         }
 
     @classmethod
@@ -96,6 +100,8 @@ class RiveterConfig:
                 flat["ai_explain_on_fail"] = ai_block["explain_on_fail"]
             if "model" in ai_block:
                 flat["ai_model"] = ai_block["model"]
+            if "generate_model" in ai_block:
+                flat["ai_generate_model"] = ai_block["generate_model"]
 
         valid = {f for f in cls.__dataclass_fields__}
         filtered = {k: v for k, v in flat.items() if k in valid and v is not None}
@@ -137,6 +143,7 @@ class RiveterConfig:
         # AI settings: override wins when it differs from default
         merged.ai_explain_on_fail = overrides.ai_explain_on_fail or self.ai_explain_on_fail
         merged.ai_model = overrides.ai_model or self.ai_model
+        merged.ai_generate_model = overrides.ai_generate_model or self.ai_generate_model
 
         return merged
 

--- a/src/riveter/generator.py
+++ b/src/riveter/generator.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2026 Scott Howard
+# SPDX-License-Identifier: MIT
+
+"""LLM-assisted rule generation via the Anthropic API.
+
+Usage:
+    generator = RuleGenerator(model="claude-sonnet-4-20250514")
+    if generator.is_available():
+        rules = generator.generate_for_resource_type(resource_type, sample_resource, focus=focus)
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from .exceptions import RuleValidationError
+from .rules import Rule
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+_RULE_SCHEMA_REFERENCE = """\
+Each rule must have this YAML structure:
+
+  - id: unique-kebab-case-id          # required: lowercase letters, digits, hyphens
+    resource_type: aws_instance       # required: Terraform resource type (e.g. aws_instance)
+    description: Human-readable text  # optional but recommended
+    severity: error | warning | info  # optional, defaults to error
+    filter:                           # optional: only apply rule when these attrs match
+      tags.Environment: production
+    assert:                           # required: one or more assertions (all must pass)
+      root_block_device.encrypted: true
+    metadata:                         # optional
+      tags: [security]
+      references:
+        - https://example.com/docs
+
+Supported assertion operators (used as nested dict under the attribute path):
+  eq, ne          — equality / inequality
+  gt, gte         — greater than, greater than or equal
+  lt, lte         — less than, less than or equal
+  regex           — regular expression match (string)
+  contains        — list contains a value
+  length          — list or string length check (int for exact, or dict with operators)
+  subset          — list is a subset of another
+  present         — value exists and is non-empty (use as a bare keyword value: present)
+
+Simple equality is written without an operator:
+  instance_type: t3.micro            # equals "t3.micro"
+  root_block_device.encrypted: true  # equals true
+
+Nested paths use dot-notation:
+  root_block_device.encrypted        # nested object
+  tags.Environment                   # tag value
+  ingress[0].cidr_blocks             # array element"""
+
+_FEW_SHOT_EXAMPLES = """\
+Example rules for reference:
+
+rules:
+  - id: ec2-must-be-encrypted
+    resource_type: aws_instance
+    description: All EC2 root EBS volumes must be encrypted
+    severity: error
+    assert:
+      root_block_device.encrypted: true
+    metadata:
+      tags: [encryption, ec2]
+
+  - id: ec2-approved-instance-types
+    resource_type: aws_instance
+    description: EC2 instances must use approved instance types
+    severity: warning
+    assert:
+      instance_type:
+        regex: "^(t3|t4g|m5|m6i)\\\\.(micro|small|medium|large|xlarge|2xlarge)$"
+
+  - id: ec2-required-tags
+    resource_type: aws_instance
+    description: EC2 instances must have required governance tags
+    severity: error
+    assert:
+      tags.Environment: present
+      tags.Owner: present"""
+
+
+class RuleGenerator:
+    """Generates Riveter rules for a given Terraform resource type using Claude.
+
+    The Anthropic client is lazily imported — the class is safe to instantiate
+    even when the ``anthropic`` package is not installed or no API key is set.
+    """
+
+    def __init__(self, model: Optional[str] = None) -> None:
+        self._model = model or _DEFAULT_MODEL
+        self._client: Any = None  # anthropic.Anthropic once initialized
+        self._available = False
+        self._auth_error = False
+        self._rate_limit_error = False
+        self._timeout_error = False
+        self._connection_error = False
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            try:
+                import anthropic  # noqa: PLC0415
+
+                self._client = anthropic.Anthropic(api_key=api_key)
+                self._available = True
+            except ImportError:
+                log.debug("anthropic package not installed; AI rule generation unavailable")
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Return True only if ANTHROPIC_API_KEY is set and anthropic is installed."""
+        return self._available
+
+    def generate_for_resource_type(
+        self,
+        resource_type: str,
+        sample_resource: Dict[str, Any],
+        focus: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Generate 3–5 Riveter rules for a given Terraform resource type.
+
+        Args:
+            resource_type:   Terraform resource type (e.g. ``aws_instance``).
+            sample_resource: A representative resource attribute dict for context.
+            focus:           Optional plain-text guidance, e.g. "PCI-DSS compliance"
+                             or "cost optimization".
+
+        Returns:
+            List of validated rule dicts ready for YAML serialisation.
+            Returns an empty list on any failure.
+        """
+        if not self._available or self._client is None:
+            return []
+
+        prompt = self._build_prompt(resource_type, sample_resource, focus)
+        try:
+            message = self._client.messages.create(
+                model=self._model,
+                max_tokens=2000,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            content = message.content
+            if content and hasattr(content[0], "text"):
+                raw = str(content[0].text).strip()
+                return self._parse_and_validate(raw, resource_type)
+            return []
+        except Exception as exc:  # noqa: BLE001
+            self._classify_error(exc)
+            log.debug("Anthropic API error during rule generation: %s", exc)
+            return []
+
+    def get_warning(self) -> Optional[str]:
+        """Return a one-line warning if any API errors occurred.
+
+        Returns None if no errors occurred.
+        """
+        if self._auth_error:
+            return (
+                "✗ Anthropic API key is invalid or expired. "
+                "Check your key at console.anthropic.com"
+            )
+        if self._rate_limit_error:
+            return "✗ Anthropic rate limit hit. Some resource types may have been skipped."
+        if self._timeout_error:
+            return "✗ Could not reach Anthropic API. Some resource types may have been skipped."
+        if self._connection_error:
+            return "✗ Anthropic API call failed. Run with --debug for details."
+        return None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _classify_error(self, exc: Exception) -> None:
+        name = type(exc).__name__
+        if "Authentication" in name or "Auth" in name:
+            self._auth_error = True
+        elif "RateLimit" in name:
+            self._rate_limit_error = True
+        elif "Timeout" in name or "timeout" in name.lower():
+            self._timeout_error = True
+        else:
+            self._connection_error = True
+
+    def _build_prompt(
+        self,
+        resource_type: str,
+        sample_resource: Dict[str, Any],
+        focus: Optional[str],
+    ) -> str:
+        # Strip internal riveter keys to keep the prompt clean
+        attrs: Dict[str, Any] = {
+            k: v for k, v in sample_resource.items() if k not in ("resource_type", "id")
+        }
+        attrs_yaml = yaml.dump(attrs, default_flow_style=False).strip()
+
+        focus_line = (
+            f"\nFocus area: {focus}\n"
+            if focus
+            else "\nFocus area: general security and operational best practices\n"
+        )
+
+        return (
+            "You are an infrastructure security expert. Generate Riveter rules for the "
+            f"Terraform resource type '{resource_type}'.\n"
+            f"{focus_line}\n"
+            f"{_RULE_SCHEMA_REFERENCE}\n\n"
+            f"{_FEW_SHOT_EXAMPLES}\n\n"
+            f"Here is a sample '{resource_type}' resource from the user's Terraform:\n\n"
+            f"{attrs_yaml}\n\n"
+            "Generate 3-5 rules specifically for this resource type. Rules must:\n"
+            "  - Use only attributes visible in the sample resource or commonly present "
+            f"on '{resource_type}' resources\n"
+            "  - Be actionable and enforceable (not aspirational)\n"
+            "  - Cover different aspects (encryption, access control, tagging, etc.) "
+            "where applicable\n\n"
+            "Return ONLY a valid YAML block starting with 'rules:' and nothing else. "
+            "No explanation, no markdown fences, no preamble."
+        )
+
+    def _parse_and_validate(
+        self, raw: str, resource_type: str
+    ) -> List[Dict[str, Any]]:
+        """Parse LLM YAML output and validate each rule. Silently drops invalid ones."""
+        # Strip accidental markdown code fences
+        text = raw.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            # Drop first and last fence lines
+            if lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            text = "\n".join(lines)
+
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            log.debug("Failed to parse generated YAML for %s: %s", resource_type, exc)
+            return []
+
+        if not isinstance(parsed, dict):
+            log.debug("Generated output for %s is not a YAML dict", resource_type)
+            return []
+
+        rules_list = parsed.get("rules", [])
+        if not isinstance(rules_list, list):
+            log.debug("Generated 'rules' key for %s is not a list", resource_type)
+            return []
+
+        valid: List[Dict[str, Any]] = []
+        for rule_dict in rules_list:
+            if not isinstance(rule_dict, dict):
+                continue
+            try:
+                Rule(rule_dict)
+                valid.append(rule_dict)
+            except (RuleValidationError, Exception) as exc:  # noqa: BLE001
+                log.debug(
+                    "Dropping invalid generated rule '%s': %s",
+                    rule_dict.get("id", "<unknown>"),
+                    exc,
+                )
+
+        return valid

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,333 @@
+"""Tests for the AI-powered rule generator."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from riveter.generator import RuleGenerator
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+_SAMPLE_RESOURCE = {
+    "id": "web_server",
+    "resource_type": "aws_instance",
+    "instance_type": "t3.micro",
+    "ami": "ami-0c55b159cbfafe1f0",
+    "associate_public_ip_address": True,
+    "root_block_device": {"encrypted": False, "volume_size": 20},
+    "tags": {"Environment": "production", "Owner": "team@example.com"},
+}
+
+_VALID_RULES_YAML = """\
+rules:
+  - id: ec2-must-be-encrypted
+    resource_type: aws_instance
+    description: EC2 root volumes must be encrypted
+    severity: error
+    assert:
+      root_block_device.encrypted: true
+
+  - id: ec2-required-tags
+    resource_type: aws_instance
+    description: EC2 instances must have required tags
+    severity: error
+    assert:
+      tags.Environment: present
+      tags.Owner: present
+"""
+
+_YAML_WITH_INVALID_RULE = """\
+rules:
+  - id: ec2-valid-rule
+    resource_type: aws_instance
+    description: A valid rule
+    severity: error
+    assert:
+      root_block_device.encrypted: true
+
+  - id: ""
+    resource_type: aws_instance
+    assert:
+      some_attr: true
+
+  - resource_type: aws_instance
+    assert:
+      some_attr: true
+"""
+
+
+# ---------------------------------------------------------------------------
+# Availability tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_returns_false_without_env_var():
+    """RuleGenerator.is_available() must be False when ANTHROPIC_API_KEY is not set."""
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    with patch.dict(os.environ, env, clear=True):
+        generator = RuleGenerator()
+        assert generator.is_available() is False
+
+
+def test_is_available_returns_false_when_package_missing():
+    """RuleGenerator.is_available() must be False when anthropic is not installed."""
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test"}):
+        with patch("builtins.__import__", side_effect=ImportError("No module named 'anthropic'")):
+            generator = RuleGenerator()
+            assert generator.is_available() is False
+
+
+def test_is_available_returns_true_with_key_and_package():
+    """RuleGenerator.is_available() is True when key is set and package importable."""
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test"}):
+        mock_anthropic = MagicMock()
+        with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+            generator = RuleGenerator()
+            assert generator.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# generate_for_resource_type – success path
+# ---------------------------------------------------------------------------
+
+
+def _make_generator_returning(yaml_text: str) -> RuleGenerator:
+    """Return a RuleGenerator whose client responds with the given YAML text."""
+    mock_content = MagicMock()
+    mock_content.text = yaml_text
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+
+    generator = RuleGenerator()
+    generator._available = True
+    generator._client = mock_client
+    return generator
+
+
+def test_generate_returns_list_of_dicts_on_success():
+    """generate_for_resource_type returns a list of dicts for valid YAML."""
+    generator = _make_generator_returning(_VALID_RULES_YAML)
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert isinstance(rules, list)
+    assert len(rules) == 2
+    assert all(isinstance(r, dict) for r in rules)
+
+
+def test_generated_rules_have_required_fields():
+    """Each returned rule dict has id, resource_type, and assert keys."""
+    generator = _make_generator_returning(_VALID_RULES_YAML)
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    for rule in rules:
+        assert "id" in rule
+        assert "resource_type" in rule
+        assert "assert" in rule
+
+
+def test_invalid_rules_are_silently_dropped():
+    """Rules with empty id or missing required fields are dropped; valid ones kept."""
+    generator = _make_generator_returning(_YAML_WITH_INVALID_RULE)
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert len(rules) == 1
+    assert rules[0]["id"] == "ec2-valid-rule"
+
+
+def test_generate_strips_markdown_fences():
+    """LLM output wrapped in markdown fences is parsed correctly."""
+    fenced = f"```yaml\n{_VALID_RULES_YAML}```"
+    generator = _make_generator_returning(fenced)
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert len(rules) == 2
+
+
+def test_generate_returns_empty_on_api_error():
+    """generate_for_resource_type returns [] when the Anthropic client raises."""
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = Exception("simulated API error")
+
+    generator = RuleGenerator()
+    generator._available = True
+    generator._client = mock_client
+
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert rules == []
+
+
+def test_generate_returns_empty_when_unavailable():
+    """generate_for_resource_type returns [] immediately when is_available() is False."""
+    with patch.dict(os.environ, {}, clear=True):
+        generator = RuleGenerator()
+        assert generator.is_available() is False
+        rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+        assert rules == []
+
+
+def test_generate_returns_empty_on_invalid_yaml():
+    """generate_for_resource_type returns [] when LLM returns unparseable text."""
+    generator = _make_generator_returning("this is not yaml: [[[")
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert rules == []
+
+
+def test_generate_returns_empty_when_no_rules_key():
+    """generate_for_resource_type returns [] when YAML has no 'rules' key."""
+    generator = _make_generator_returning("some_other_key:\n  - foo: bar\n")
+    rules = generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    assert rules == []
+
+
+# ---------------------------------------------------------------------------
+# Prompt content tests
+# ---------------------------------------------------------------------------
+
+
+def _capture_prompt(yaml_text: str = _VALID_RULES_YAML) -> str:
+    """Return the prompt string sent to the Anthropic client."""
+    captured: list[str] = []
+
+    mock_content = MagicMock()
+    mock_content.text = yaml_text
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+
+    def fake_create(**kwargs: object) -> MagicMock:
+        messages = kwargs.get("messages", [])
+        for msg in messages:
+            if isinstance(msg, dict):
+                captured.append(str(msg.get("content", "")))
+        return mock_response
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = fake_create
+
+    generator = RuleGenerator()
+    generator._available = True
+    generator._client = mock_client
+    generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE)
+    return captured[0] if captured else ""
+
+
+def test_prompt_contains_resource_type():
+    """Prompt must mention the resource type being analyzed."""
+    prompt = _capture_prompt()
+    assert "aws_instance" in prompt
+
+
+def test_prompt_contains_operator_examples():
+    """Prompt must describe the available assertion operators."""
+    prompt = _capture_prompt()
+    assert "regex" in prompt
+    assert "present" in prompt
+    assert "gte" in prompt
+
+
+def test_prompt_contains_focus_when_provided():
+    """Optional focus string must appear in the prompt."""
+    captured: list[str] = []
+
+    mock_content = MagicMock()
+    mock_content.text = _VALID_RULES_YAML
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+
+    def fake_create(**kwargs: object) -> MagicMock:
+        messages = kwargs.get("messages", [])
+        for msg in messages:
+            if isinstance(msg, dict):
+                captured.append(str(msg.get("content", "")))
+        return mock_response
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = fake_create
+
+    generator = RuleGenerator()
+    generator._available = True
+    generator._client = mock_client
+    generator.generate_for_resource_type("aws_instance", _SAMPLE_RESOURCE, focus="PCI-DSS")
+
+    assert captured
+    assert "PCI-DSS" in captured[0]
+
+
+def test_prompt_contains_resource_attributes():
+    """Prompt must include actual resource attributes from the sample."""
+    prompt = _capture_prompt()
+    # The sample resource has these attributes
+    assert "t3.micro" in prompt
+    assert "root_block_device" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Warning / error classification tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_warning_returns_none_on_success():
+    """No warning when no errors have occurred."""
+    generator = RuleGenerator()
+    assert generator.get_warning() is None
+
+
+def test_get_warning_auth_error():
+    generator = RuleGenerator()
+    generator._auth_error = True
+    warning = generator.get_warning()
+    assert warning is not None
+    assert "invalid or expired" in warning
+
+
+def test_get_warning_rate_limit():
+    generator = RuleGenerator()
+    generator._rate_limit_error = True
+    warning = generator.get_warning()
+    assert warning is not None
+    assert "rate limit" in warning.lower()
+
+
+def test_get_warning_timeout():
+    generator = RuleGenerator()
+    generator._timeout_error = True
+    warning = generator.get_warning()
+    assert warning is not None
+    assert "reach Anthropic" in warning
+
+
+def test_classify_error_sets_auth_flag():
+    generator = RuleGenerator()
+
+    class AuthenticationError(Exception):
+        pass
+
+    generator._classify_error(AuthenticationError("invalid key"))
+    assert generator._auth_error is True
+
+
+def test_classify_error_sets_rate_limit_flag():
+    generator = RuleGenerator()
+
+    class RateLimitError(Exception):
+        pass
+
+    generator._classify_error(RateLimitError("too many requests"))
+    assert generator._rate_limit_error is True
+
+
+def test_classify_error_sets_timeout_flag():
+    generator = RuleGenerator()
+
+    class TimeoutError(Exception):
+        pass
+
+    generator._classify_error(TimeoutError("request timed out"))
+    assert generator._timeout_error is True
+
+
+def test_classify_error_sets_connection_flag_for_unknown():
+    generator = RuleGenerator()
+    generator._classify_error(Exception("some unknown error"))
+    assert generator._connection_error is True


### PR DESCRIPTION
Adds a new `generate-rules` CLI command that parses a user's Terraform
files and calls Claude to suggest 3-5 enforceable Riveter rules per
resource type.  Generated rules are validated through the existing Rule
class before output, and can be piped directly into `riveter scan -r`.

- src/riveter/generator.py: new RuleGenerator class (mirrors Explainer
  pattern) with lazy Anthropic import, per-resource-type prompting,
  YAML parsing, and Rule validation/filtering of LLM output
- src/riveter/cli.py: new `generate-rules` command with --terraform,
  --output, --focus, --model, and --debug flags; concurrent generation
  via ThreadPoolExecutor
- src/riveter/config.py: add ai_generate_model field (maps from
  ai.generate_model in riveter.yml)
- tests/test_generator.py: 23 unit tests covering availability,
  success path, error handling, prompt content, and warning messages

https://claude.ai/code/session_012EZEhgqLhciDYpgdKAvN38